### PR TITLE
Fix JDK class javadoc/sources

### DIFF
--- a/internal/java/database.go
+++ b/internal/java/database.go
@@ -4,12 +4,10 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/brandtg/rtfm/internal/common"
 )
 
-// TODO Change this to have the application key as the primary key
 func createTables(db *sql.DB) error {
 	_, err := db.Exec(`
     CREATE TABLE IF NOT EXISTS java_class (
@@ -125,10 +123,10 @@ func listJavaClasses(
 }
 
 func fetchJavaClass(db *sql.DB, target string) (*JavaClass, error) {
-	tokens := strings.Split(target, ":")
-	if len(tokens) != 4 {
-		return nil, fmt.Errorf("invalid target format: %s", target)
-	}
+	// tokens := strings.Split(target, ":")
+	// if len(tokens) != 4 {
+	// 	return nil, fmt.Errorf("invalid target format: %s", target)
+	// }
 	rows, err := db.Query(`
         SELECT
             name
@@ -141,11 +139,8 @@ func fetchJavaClass(db *sql.DB, target string) (*JavaClass, error) {
         FROM
             java_class
         WHERE
-            artifact_group_id = ?
-            AND artifact_id = ?
-            AND artifact_version = ?
-            AND name = ?
-    `, tokens[0], tokens[1], tokens[2], tokens[3])
+			key = ?
+    `, target)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/java/indexer.go
+++ b/internal/java/indexer.go
@@ -216,7 +216,7 @@ func jdkClassUrl(link Link) string {
 	suffix := tokens[1:]
 	path := append([]string{prefix, "share", "classes"}, suffix...)
 	url := strings.Join(path, "/")
-	url = "https://github.com/openjdk/jdk/blob/master/src/" + strings.ReplaceAll(url, ".html", ".java")
+	url = "https://raw.githubusercontent.com/openjdk/jdk/refs/heads/master/src/" + strings.ReplaceAll(url, ".html", ".java")
 	return url
 }
 

--- a/internal/java/types.go
+++ b/internal/java/types.go
@@ -2,6 +2,7 @@ package java
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,6 +45,18 @@ func javaOutputDir(baseOutputDir string) string {
 }
 
 func (j *JavaClass) key() string {
+	// JDK classes
+	if strings.HasPrefix(j.Path, "https://docs.oracle.com") {
+		url, err := url.Parse(j.Path)
+		if err != nil {
+			panic(err)
+		}
+		version := strings.Split(strings.Replace(url.Path, "/en/java/javase/", "", 1), "/")[0]
+		return fmt.Sprintf(
+			"jdk:java.base:%s:%s",
+			version,
+			j.Name)
+	}
 	return fmt.Sprintf(
 		"%s:%s:%s:%s",
 		j.Artifact.GroupId,

--- a/internal/java/viewer.go
+++ b/internal/java/viewer.go
@@ -2,11 +2,56 @@ package java
 
 import (
 	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/brandtg/rtfm/internal/common"
 )
+
+func readJavaSource(outputDir string, javaClass *JavaClass) (string, error) {
+	if strings.HasPrefix(javaClass.Source, "http") {
+		// Check if we've cached the file
+		cachedFile := filepath.Join(outputDir, "sources", "_jdk", javaClass.Name)
+		if common.Exists(cachedFile) {
+			// Read it
+			data, err := os.ReadFile(cachedFile)
+			if err != nil {
+				return "", err
+			}
+			return string(data), nil
+		}
+		// Fetch the HTML from the web
+		resp, err := http.Get(javaClass.Source)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
+		// Cache the result
+		err = os.MkdirAll(filepath.Dir(cachedFile), 0755)
+		if err != nil {
+			slog.Warn("Failed to create javadoc cache directory", "path", cachedFile, "error", err)
+		}
+		err = os.WriteFile(cachedFile, bodyBytes, 0644)
+		if err != nil {
+			slog.Warn("Failed to cache javadoc HTML", "path", javaClass.Path, "error", err)
+		}
+		return string(bodyBytes), nil
+	}
+	// Read HTML from the file
+	source, err := os.ReadFile(filepath.Join(outputDir, javaClass.Source))
+	if err != nil {
+		return "", err
+	}
+	return string(source), nil
+}
 
 func View(baseOutputDir string, target string, showSource bool) (*JavaClass, error) {
 	outputDir := javaOutputDir(baseOutputDir)
@@ -23,7 +68,7 @@ func View(baseOutputDir string, target string, showSource bool) (*JavaClass, err
 	}
 	if showSource {
 		// Output the source code
-		source, err := os.ReadFile(filepath.Join(outputDir, javaClass.Source))
+		source, err := readJavaSource(outputDir, javaClass)
 		if err != nil {
 			return nil, err
 		}
@@ -34,7 +79,10 @@ func View(baseOutputDir string, target string, showSource bool) (*JavaClass, err
 		fmt.Println(code)
 	} else {
 		// Format the Javadoc as Markdown
-		markdown := FormatMarkdown(outputDir, javaClass)
+		markdown, err := FormatMarkdown(outputDir, javaClass)
+		if err != nil {
+			return nil, err
+		}
 		fmt.Println(markdown)
 	}
 	return javaClass, nil


### PR DESCRIPTION
- Special case JDK class urls in key generation
- Use key in java lookup
- Use raw source instead of github page
- Fetch javadoc from oracle for JDK classes
- Fetch java source from github for jdk classes
